### PR TITLE
Don't crash if Share comms are in progress when initialized

### DIFF
--- a/G4ShareSpy/Info.plist
+++ b/G4ShareSpy/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.2.1</string>
+	<string>0.2.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/G4ShareSpy/Receiver.swift
+++ b/G4ShareSpy/Receiver.swift
@@ -50,7 +50,7 @@ public class Receiver: BluetoothManagerDelegate {
     func bluetoothManager(manager: BluetoothManager, didReceiveBytes bytes: NSData) {
         if messageInProgress {
             append(bytes)
-        } else if let header = MessageHeader(data: bytes[0...3]) {
+        } else if bytes.length >= 4, let header = MessageHeader(data: bytes[0...3]) {
             messageInProgress = true
             receivedBytes = 0
             expectedBytes = header.totalBytes

--- a/G4ShareSpy/Receiver.swift
+++ b/G4ShareSpy/Receiver.swift
@@ -8,11 +8,6 @@
 
 import Foundation
 
-public enum ReceiverError: ErrorType {
-    case UnexpectedBytes(data: NSData)
-    case BadCRC(data: NSData)
-}
-
 public protocol ReceiverDelegate: class {
     func receiver(receiver: Receiver, didReadGlucoseHistory glucoseHistory: [GlucoseG4])
 
@@ -55,16 +50,12 @@ public class Receiver: BluetoothManagerDelegate {
     func bluetoothManager(manager: BluetoothManager, didReceiveBytes bytes: NSData) {
         if messageInProgress {
             append(bytes)
-        } else {
-            if let header = MessageHeader(data: bytes[0...3]) {
-                messageInProgress = true
-                receivedBytes = 0
-                expectedBytes = header.totalBytes
-                message = NSMutableData(capacity: Int(expectedBytes))
-                append(bytes)
-            } else {
-                self.delegate?.receiver(self, didError: ReceiverError.UnexpectedBytes(data: bytes))
-            }
+        } else if let header = MessageHeader(data: bytes[0...3]) {
+            messageInProgress = true
+            receivedBytes = 0
+            expectedBytes = header.totalBytes
+            message = NSMutableData(capacity: Int(expectedBytes))
+            append(bytes)
         }
     }
 
@@ -85,11 +76,6 @@ public class Receiver: BluetoothManagerDelegate {
     }
 
     private func parseMessage(message: NSData, receivedAt: NSDate) {
-        guard message.crcValid() else {
-            self.delegate?.receiver(self, didError: ReceiverError.BadCRC(data: message))
-            return
-        }
-
         if let systemTimeMessage = SystemTimeMessage(data: message) {
             clockOffset = receivedAt.timeIntervalSince1970 - Double(systemTimeMessage.time)
             if let pending = glucoseHistoryAwaitingClock {


### PR DESCRIPTION
In the event that `Receiver` is initialized when the Share app is communicating with the receiver, and the receiver is in the middle of sending a message, and one chunk of the message is less than 4 bytes, there will be a crash. This fixes it.

Also: stop surfacing `BadCRC` and `UnexpectedBytes` errors, as they occur only in this case, and are not truly errors. `didError` now reports only real errors (from `BluetoothManager`).
